### PR TITLE
Bump deno version and migrate to official image

### DIFF
--- a/ritrin/Dockerfile
+++ b/ritrin/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukechannings/deno:v1.40.2
+FROM denoland/deno:distroless-1.41.0
 
 WORKDIR /app
 


### PR DESCRIPTION
Official Linux ARM64 Deno is available since v1.41.0 :tada:
https://deno.com/blog/v1.41#linux-arm64-support